### PR TITLE
Fix dash manifest using SegmentList

### DIFF
--- a/lib/src/cmaf/manifest-samples/dash-samples/sample-1/manifest-sample-1.mpd
+++ b/lib/src/cmaf/manifest-samples/dash-samples/sample-1/manifest-sample-1.mpd
@@ -1,35 +1,29 @@
-<?xml version="1.0" encoding="utf-8"?>
-<MPD
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011"
-type="static"
-xmlns="urn:mpeg:dash:schema:mpd:2011"
-profiles="urn:mpeg:dash:profile:isoff-main:2011"
-mediaPresentationDuration="PT31.296S"
-minBufferTime="PT10S">
-    <Period duration="PT31.296S" id="evo-dash" start="PT0S">
-        <AdaptationSet maxFrameRate="3000" maxHeight="1080" maxWidth="1920" par="16:9" segmentAlignment="true" startWithSAP="0">
-            <ContentComponent contentType="video" id="1"/>
-            <Representation bandwidth="72000" codecs="avc1.42c01e" frameRate="37" height="480" id="testStream01bbbVideo72000" mimeType="video/mp4" sar="1:1" width="854">
-                <SegmentList duration="10000" timescale="1000">
-                    <Initialization sourceURL="testStream01bbb/video/72000/seg_init.mp4"/>
-                    <SegmentURL media="testStream01bbb/video/72000/segment_0.m4s"/>
-                    <SegmentURL media="testStream01bbb/video/72000/segment_10417.m4s"/>
-                    <SegmentURL media="testStream01bbb/video/72000/segment_20833.m4s"/>
-                </SegmentList>
-            </Representation>
-        </AdaptationSet>
-        <AdaptationSet lang="en" segmentAlignment="true" startWithSAP="0">
-            <ContentComponent contentType="audio" id="2"/>
-            <Representation audioSamplingRate="48000" bandwidth="72000" codecs="mp4a.40.2" id="testStream01bbbAudio72000" mimeType="audio/mp4">
-                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
-                <SegmentList duration="10000" timescale="1000">
-                    <Initialization sourceURL="testStream01bbb/audio/72000/seg_init.mp4"/>
-                    <SegmentURL media="testStream01bbb/audio/72000/segment_0.m4s"/>
-                    <SegmentURL media="testStream01bbb/audio/72000/segment_10432.m4s"/>
-                    <SegmentURL media="testStream01bbb/audio/72000/segment_20864.m4s"/>
-                </SegmentList>
-            </Representation>
-        </AdaptationSet>
-    </Period>
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="static" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-main:2011" mediaPresentationDuration="PT50S">
+  <Period start="PT0S" duration="PT50S" id="1">
+    <AdaptationSet mimeType="video/mp4" frameRate="30/1" segmentAlignment="true" subsegmentAlignment="true" startWithSAP="1" subsegmentStartsWithSAP="1" bitstreamSwitching="false">
+      <SegmentList timescale="90000" duration="900000">
+        <Initialization sourceURL="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleh264-videoinit.cmfv" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleh264-video_000000001.cmfv" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleh264-video_000000002.cmfv" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleh264-video_000000003.cmfv" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleh264-video_000000004.cmfv" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleh264-video_000000005.cmfv" />
+      </SegmentList>
+      <Representation id="1" width="1920" height="1080" bandwidth="2000000" codecs="avc1.640028"/>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" lang="und" segmentAlignment="0">
+      <SegmentList timescale="48000" duration="900000">
+        <Initialization sourceURL="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleaac-audioinit.cmfa" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleaac-audio_000000001.cmfa" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleaac-audio_000000002.cmfa" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleaac-audio_000000003.cmfa" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleaac-audio_000000004.cmfa" />
+        <SegmentURL media="https://cmaf-ham-sample-bucket.s3.amazonaws.com/output-mediaconvert/big buck bunny sampleaac-audio_000000005.cmfa" />
+      </SegmentList>
+      <Representation id="2" bandwidth="96000" audioSamplingRate="48000" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
 </MPD>


### PR DESCRIPTION
## Description
Fixed segmentList manifest with an actual manifest that can be watched.
Can use following [dash player permalink](https://players.akamai.com/players/dashjs?streamUrl=https%3A%2F%2Fcmaf-ham-sample-bucket.s3.amazonaws.com%2Foutput-mediaconvert%2Fbig%252Bbuck%252Bbunny%252Bsample.mpd) to test.

## Requirements Checklist
- [ ] Unit Tests updated or fixed
- [ ] Docs/guides updated
