### PR TITLE
cmcdv2/Convert cmcd V1 request to V2 requests

### DIFF
--- a/lib/src/cmcd/CmcdV2ToCmcdV1.ts
+++ b/lib/src/cmcd/CmcdV2ToCmcdV1.ts
@@ -21,7 +21,7 @@ type CmcdData = Record<string, string | number | boolean>;
 *
 * @param cmcdData - The CMCD data object.
 *
-* @returns Updated list of keys v1 keys.
+* @returns Updated list of v1 keys.
 *
 * @group CMCD
 *

--- a/lib/src/cmcd/CmcdV2ToCmcdV1.ts
+++ b/lib/src/cmcd/CmcdV2ToCmcdV1.ts
@@ -1,4 +1,5 @@
 import type { Cmcd } from './Cmcd';
+import { CmcdV1Keys } from './CmcdV1Keys.js';
 
 /**
 * Type definition for valid CMCD keys.
@@ -6,10 +7,7 @@ import type { Cmcd } from './Cmcd';
 type CmcdKey = keyof Cmcd;
 
 // Keys supported in CMCD v1 spec
-const CMCD_V1_KEYS: Set<CmcdKey> = new Set([
-	'br', 'bl', 'bs', 'cid', 'd', 'dl', 'mtp', 'nor', 'nrr',
-	'ot', 'pr', 'rtp', 'sf', 'sid', 'st', 'su', 'tb', 'v',
-]);
+const CMCD_V1_KEYS: Set<CmcdKey> = new Set(CmcdV1Keys);
 
 /**
 * Type definition for a CMCD key-value object.

--- a/lib/src/cmcd/CmcdV2ToCmcdV1.ts
+++ b/lib/src/cmcd/CmcdV2ToCmcdV1.ts
@@ -1,0 +1,38 @@
+import type { Cmcd } from './Cmcd';
+
+/**
+* Type definition for valid CMCD keys.
+*/
+type CmcdKey = keyof Cmcd;
+
+// Keys supported in CMCD v1 spec
+const CMCD_V1_KEYS: Set<CmcdKey> = new Set([
+	'br', 'bl', 'bs', 'cid', 'd', 'dl', 'mtp', 'nor', 'nrr',
+	'ot', 'pr', 'rtp', 'sf', 'sid', 'st', 'su', 'tb', 'v',
+]);
+
+/**
+* Type definition for a CMCD key-value object.
+*/
+type CmcdData = Record<string, string | number | boolean>;
+
+/**
+* Converts a CMCD V2 request to a CMCD V1 request
+*
+* @param cmcdData - The CMCD data object.
+*
+* @returns Updated list of keys v1 keys.
+*
+* @group CMCD
+*
+* @beta
+*/
+export function convertToCmcdV1(cmcdData: CmcdData): CmcdData {
+	const result: CmcdData = {};
+	for (const key in cmcdData) {
+		if (CMCD_V1_KEYS.has(key as CmcdKey)) {
+			result[key as CmcdKey] = cmcdData[key as CmcdKey];
+		}
+	}
+	return result;
+}


### PR DESCRIPTION
Added function that removes v2 keys from a CMCD request, converting it to a V1 request
